### PR TITLE
Check Repository Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml
+        python -m pytest tests/ -v --cov=src --cov-report=xml
 
     - name: Upload coverage to Codecov (Ubuntu only)
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "lenslogic"
 version = "1.0.2"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.8"
 dependencies = []
 
 [tool.ruff]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyinstaller>=6.0.0
 matplotlib>=3.7.0
 imagehash>=4.3.0
 send2trash>=1.8.0
+cffi>=1.15.0


### PR DESCRIPTION
- Update pyproject.toml: Change Python requirement from >=3.13 to >=3.8 to match CI workflow
- Add cffi>=1.15.0 to requirements.txt: Required by PyInstaller for cryptography support
- Update CI workflow: Use 'python -m pytest' instead of 'pytest' for better compatibility

These changes resolve:
1. Python version mismatch between pyproject.toml and CI matrix
2. ModuleNotFoundError for _cffi_backend during PyInstaller build
3. Potential pytest import issues in CI environment