### PR TITLE
Fix Python 3.8 type hint compatibility issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,12 +3,12 @@ name = "lenslogic"
 version = "1.0.2"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.8"
 dependencies = []
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py38"
 
 [tool.ruff.lint]
 select = [
@@ -21,6 +21,10 @@ select = [
 ]
 ignore = [
     "E501",  # Line too long - let ruff-format handle it
+    "UP006", # Use `dict` instead of `Dict` - not compatible with Python 3.8
+    "UP007", # Use `X | Y` for type annotations - not compatible with Python 3.8
+    "UP035", # `typing.Dict` is deprecated - not in Python 3.8
+    "UP045", # Use `X | None` instead of `Optional[X]` - not compatible with Python 3.8
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from modules.backup_manager import BackupManager
 from modules.config_wizard import ConfigurationWizard
@@ -24,7 +24,7 @@ from utils.progress_tracker import ProgressTracker
 
 
 class LensLogic:
-    def __init__(self, config_path: str | None = None, args: dict[str, Any] | None = None):
+    def __init__(self, config_path: Optional[str] = None, args: Optional[Dict[str, Any]] = None):
         self.config_manager = ConfigManager(config_path)
 
         # Store custom destination separately - don't save to config
@@ -68,7 +68,7 @@ class LensLogic:
             ],
         )
 
-    def organize_photos(self, dry_run: bool = False, custom_destination: str | None = None):
+    def organize_photos(self, dry_run: bool = False, custom_destination: Optional[str] = None):
         source_dir = Path(self.config.get("general", {}).get("source_directory", "."))
 
         # Use custom destination if provided, or class custom_destination, otherwise use config destination
@@ -200,7 +200,7 @@ class LensLogic:
 
         return success_count > 0
 
-    def _collect_files(self, source_dir: Path) -> list[Path]:
+    def _collect_files(self, source_dir: Path) -> List[Path]:
         files = []
 
         all_extensions = set()
@@ -230,7 +230,7 @@ class LensLogic:
             for ext, count in sorted(stats["file_types"].items(), key=lambda x: x[1], reverse=True)[:10]:
                 self.progress_tracker.console.print(f"  {ext}: {count} files")
 
-    def export_gps_locations(self, output_path: str | None = None):
+    def export_gps_locations(self, output_path: Optional[str] = None):
         if not output_path:
             output_path = "photo_locations.kml"
 
@@ -348,7 +348,7 @@ class LensLogic:
                 self.progress_tracker.print_info("Goodbye!")
                 break
 
-    def generate_advanced_statistics(self, output_dir: str | None = None):
+    def generate_advanced_statistics(self, output_dir: Optional[str] = None):
         """Generate comprehensive statistics with charts"""
         source_dir = self.config.get("general", {}).get("source_directory", ".")
         files = self._collect_files(Path(source_dir))
@@ -462,7 +462,7 @@ class LensLogic:
                 f"Organized {result['files_organized']} files into {result['sessions_processed']} session folders"
             )
 
-    def optimize_for_social_media(self, platform: str, format_type: str = "post", output_dir: str | None = None):
+    def optimize_for_social_media(self, platform: str, format_type: str = "post", output_dir: Optional[str] = None):
         """Optimize photos for social media platforms"""
         source_dir = self.config.get("general", {}).get("source_directory", ".")
         files = self._collect_files(Path(source_dir))
@@ -502,7 +502,7 @@ class LensLogic:
             output_path = Path(results[0]["output_path"]).parent
             self.progress_tracker.print_info(f"Optimized images saved to: {output_path}")
 
-    def backup_photos(self, destinations: list[str] | None = None, verify: bool = True):
+    def backup_photos(self, destinations: Optional[List[str]] = None, verify: bool = True):
         """Backup organized photos to specified destinations"""
         # Backup the organized photos (destination directory), not the source directory
         source_dir = self.config.get("general", {}).get("destination_directory", "./organized")
@@ -567,7 +567,7 @@ class LensLogic:
         else:
             self.progress_tracker.print_info("Configuration wizard cancelled or failed")
 
-    def analyze_xmp_library(self, library_path: str | None = None, output_dir: str | None = None):
+    def analyze_xmp_library(self, library_path: Optional[str] = None, output_dir: Optional[str] = None):
         """Analyze photo library using XMP sidecar files"""
         if not library_path:
             library_path = self.config.get("general", {}).get("source_directory", ".")

--- a/src/modules/backup_manager.py
+++ b/src/modules/backup_manager.py
@@ -5,7 +5,7 @@ import shutil
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from send2trash import send2trash
 
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class BackupManager:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.backup_config = config.get("backup", {})
         self.verification_enabled = self.backup_config.get("enable_verification", True)
@@ -24,7 +24,7 @@ class BackupManager:
 
         self.checksum_cache = self._load_checksum_cache()
 
-    def _load_checksum_cache(self) -> dict[str, dict[str, Any]]:
+    def _load_checksum_cache(self) -> Dict[str, Dict[str, Any]]:
         """Load checksum cache from file"""
         try:
             if Path(self.checksum_cache_file).exists():
@@ -43,7 +43,7 @@ class BackupManager:
         except Exception as e:
             logger.warning(f"Could not save checksum cache: {e}")
 
-    def calculate_file_checksum(self, file_path: str, algorithm: str = "sha256") -> str | None:
+    def calculate_file_checksum(self, file_path: str, algorithm: str = "sha256") -> Optional[str]:
         """Calculate checksum for a file"""
         file_path_obj = Path(file_path)
 
@@ -84,7 +84,7 @@ class BackupManager:
             logger.error(f"Error calculating checksum for {file_path_obj}: {e}")
             return None
 
-    def verify_backup(self, source_dir: str, backup_dir: str, quick_mode: bool = False) -> dict[str, Any]:
+    def verify_backup(self, source_dir: str, backup_dir: str, quick_mode: bool = False) -> Dict[str, Any]:
         """Verify backup integrity against source"""
         source_path = Path(source_dir)
         backup_path = Path(backup_dir)
@@ -158,7 +158,7 @@ class BackupManager:
 
         return result
 
-    def _get_file_list(self, directory: Path) -> list[Path]:
+    def _get_file_list(self, directory: Path) -> List[Path]:
         """Get list of all files in directory, excluding patterns"""
         files = []
 
@@ -205,7 +205,7 @@ class BackupManager:
         except Exception:
             return False
 
-    def incremental_sync(self, source_dir: str, destination_dirs: list[str], dry_run: bool = False) -> dict[str, Any]:
+    def incremental_sync(self, source_dir: str, destination_dirs: List[str], dry_run: bool = False) -> Dict[str, Any]:
         """Perform incremental sync to multiple destinations"""
         source_path = Path(source_dir)
 
@@ -280,8 +280,8 @@ class BackupManager:
         return result
 
     def _sync_to_destination(
-        self, source_path: Path, source_index: dict, dest_dir: str, dry_run: bool
-    ) -> dict[str, Any]:
+        self, source_path: Path, source_index: Dict, dest_dir: str, dry_run: bool
+    ) -> Dict[str, Any]:
         """Sync source to a single destination"""
         dest_path = Path(dest_dir)
 
@@ -360,7 +360,7 @@ class BackupManager:
 
         return result
 
-    def _needs_update(self, source_info: dict, dest_info: dict) -> bool:
+    def _needs_update(self, source_info: Dict, dest_info: Dict) -> bool:
         """Check if destination file needs updating"""
         # Check size first (quick)
         if source_info["size"] != dest_info["size"]:
@@ -384,7 +384,7 @@ class BackupManager:
             logger.error(f"Error copying {source_path} to {dest_path}: {e}")
             return False
 
-    def get_backup_status(self, source_dir: str, backup_dirs: list[str]) -> dict[str, Any]:
+    def get_backup_status(self, source_dir: str, backup_dirs: List[str]) -> Dict[str, Any]:
         """Get status of all configured backups"""
         status = {
             "source_directory": source_dir,
@@ -454,7 +454,7 @@ class BackupManager:
 
         return status
 
-    def cleanup_old_backups(self, backup_dir: str, keep_days: int = 30, dry_run: bool = False) -> dict[str, Any]:
+    def cleanup_old_backups(self, backup_dir: str, keep_days: int = 30, dry_run: bool = False) -> Dict[str, Any]:
         """Clean up old backup files"""
         backup_path = Path(backup_dir)
 
@@ -501,11 +501,11 @@ class BackupManager:
         self,
         backup_dir: str,
         restore_dir: str,
-        file_patterns: list[str] | None = None,
+        file_patterns: Optional[List[str]] = None,
         preserve_structure: bool = True,
         overwrite_newer: bool = True,
         dry_run: bool = False,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Restore files from backup to specified directory"""
         backup_path = Path(backup_dir)
         restore_path = Path(restore_dir)
@@ -590,7 +590,7 @@ class BackupManager:
         result["restore_time"] = time.time() - start_time
         return result
 
-    def list_backup_contents(self, backup_dir: str, show_details: bool = False) -> dict[str, Any]:
+    def list_backup_contents(self, backup_dir: str, show_details: bool = False) -> Dict[str, Any]:
         """List contents of a backup directory with optional details"""
         backup_path = Path(backup_dir)
 
@@ -648,7 +648,7 @@ class BackupManager:
 
         return result
 
-    def get_restore_candidates(self, backup_dirs: list[str]) -> dict[str, Any]:
+    def get_restore_candidates(self, backup_dirs: List[str]) -> Dict[str, Any]:
         """Get information about available restore sources"""
         candidates = {
             "available_backups": [],

--- a/src/modules/duplicate_detector.py
+++ b/src/modules/duplicate_detector.py
@@ -1,6 +1,7 @@
 import hashlib
 import logging
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 from PIL import Image
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class DuplicateDetector:
-    def __init__(self, config: dict):
+    def __init__(self, config: Dict):
         self.config = config.get("duplicate_detection", {})
         self.method = self.config.get("method", "hash")
         self.threshold = self.config.get("threshold", 0.95)
@@ -17,7 +18,7 @@ class DuplicateDetector:
         self.duplicate_folder = self.config.get("duplicate_folder", "DUPLICATES")
         self.hash_cache = {}
 
-    def find_duplicates(self, file_paths: list[str]) -> dict[str, list[str]]:
+    def find_duplicates(self, file_paths: List[str]) -> Dict[str, List[str]]:
         duplicates = {}
 
         if self.method == "hash":
@@ -29,7 +30,7 @@ class DuplicateDetector:
 
         return duplicates
 
-    def _find_by_hash(self, file_paths: list[str]) -> dict[str, list[str]]:
+    def _find_by_hash(self, file_paths: List[str]) -> Dict[str, List[str]]:
         hash_groups = {}
 
         for file_path in file_paths:
@@ -44,7 +45,7 @@ class DuplicateDetector:
 
         return duplicates
 
-    def _calculate_file_hash(self, file_path: str) -> str | None:
+    def _calculate_file_hash(self, file_path: str) -> Optional[str]:
         if file_path in self.hash_cache:
             return self.hash_cache[file_path]
 
@@ -62,7 +63,7 @@ class DuplicateDetector:
             logger.error(f"Error calculating hash for {file_path}: {e}")
             return None
 
-    def _find_by_pixels(self, file_paths: list[str]) -> dict[str, list[str]]:
+    def _find_by_pixels(self, file_paths: List[str]) -> Dict[str, List[str]]:
         duplicates = {}
         processed = set()
         image_data_cache = {}
@@ -96,7 +97,7 @@ class DuplicateDetector:
 
         return duplicates
 
-    def _get_image_array(self, file_path: str, cache: dict) -> np.ndarray | None:
+    def _get_image_array(self, file_path: str, cache: Dict) -> Optional[np.ndarray]:
         if file_path in cache:
             return cache[file_path]
 
@@ -127,7 +128,7 @@ class DuplicateDetector:
             logger.debug(f"Error comparing images: {e}")
             return False
 
-    def _find_by_histogram(self, file_paths: list[str]) -> dict[str, list[str]]:
+    def _find_by_histogram(self, file_paths: List[str]) -> Dict[str, List[str]]:
         duplicates = {}
         processed = set()
         histogram_cache = {}
@@ -161,7 +162,7 @@ class DuplicateDetector:
 
         return duplicates
 
-    def _calculate_histogram(self, file_path: str, cache: dict) -> np.ndarray | None:
+    def _calculate_histogram(self, file_path: str, cache: Dict) -> Optional[np.ndarray]:
         if file_path in cache:
             return cache[file_path]
 
@@ -213,7 +214,7 @@ class DuplicateDetector:
 
         return False
 
-    def handle_duplicate(self, original: str, duplicate: str, destination_base: str) -> tuple[str, str]:
+    def handle_duplicate(self, original: str, duplicate: str, destination_base: str) -> Tuple[str, str]:
         if self.action == "skip":
             return "skip", f"Skipping duplicate: {duplicate}"
 

--- a/src/modules/enhanced_exif_extractor.py
+++ b/src/modules/enhanced_exif_extractor.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 import exif
 from PIL import Image
@@ -110,7 +110,7 @@ class EnhancedExifExtractor:
             except Exception:
                 pass
 
-    def extract_metadata(self, file_path: str) -> dict[str, Any]:
+    def extract_metadata(self, file_path: str) -> Dict[str, Any]:
         """Extract comprehensive metadata using appropriate extractor (photo/video)"""
         file_path_obj = Path(file_path)
 
@@ -161,7 +161,7 @@ class EnhancedExifExtractor:
         self.cache[str(file_path_obj)] = metadata
         return metadata
 
-    def _extract_with_exiftool(self, file_path: Path) -> dict[str, Any]:
+    def _extract_with_exiftool(self, file_path: Path) -> Dict[str, Any]:
         """Extract metadata using PyExifTool"""
         try:
             # Get all metadata from ExifTool
@@ -238,7 +238,7 @@ class EnhancedExifExtractor:
                 for field in fields:
                     if field in exif_data:
                         value = exif_data[field]
-                        if isinstance(value, int | float) or (
+                        if isinstance(value, (int, float)) or (
                             isinstance(value, str) and value.replace(".", "").isdigit()
                         ):
                             try:
@@ -282,7 +282,7 @@ class EnhancedExifExtractor:
             logger.error(f"ExifTool extraction failed for {file_path}: {e}")
             return {}
 
-    def _extract_gps_with_exiftool(self, exif_data: dict) -> dict[str, Any] | None:
+    def _extract_gps_with_exiftool(self, exif_data: Dict) -> Optional[Dict[str, Any]]:
         """Extract GPS data using ExifTool"""
         gps_data = {}
 
@@ -342,7 +342,7 @@ class EnhancedExifExtractor:
 
         return gps_data if gps_data else None
 
-    def _extract_professional_metadata(self, exif_data: dict) -> dict[str, Any]:
+    def _extract_professional_metadata(self, exif_data: Dict) -> Dict[str, Any]:
         """Extract professional/advanced metadata fields"""
         metadata = {}
 
@@ -407,7 +407,7 @@ class EnhancedExifExtractor:
         # Flash information
         if "EXIF:Flash" in exif_data:
             flash_value = exif_data["EXIF:Flash"]
-            metadata["flash_fired"] = bool(int(flash_value) & 1) if isinstance(flash_value, int | str) else False
+            metadata["flash_fired"] = bool(int(flash_value) & 1) if isinstance(flash_value, (int, str)) else False
 
         flash_fields = {
             "flash_mode": ["MakerNotes:FlashMode"],
@@ -433,7 +433,7 @@ class EnhancedExifExtractor:
 
         return metadata
 
-    def _parse_exiftool_datetime(self, datetime_string: str) -> datetime | None:
+    def _parse_exiftool_datetime(self, datetime_string: str) -> Optional[datetime]:
         """Parse datetime from ExifTool output"""
         if not datetime_string:
             return None
@@ -522,7 +522,7 @@ class EnhancedExifExtractor:
         }
         return file_path.suffix.lower() in supported_extensions
 
-    def _extract_with_legacy_methods(self, file_path: Path) -> dict[str, Any]:
+    def _extract_with_legacy_methods(self, file_path: Path) -> Dict[str, Any]:
         """Fallback to legacy EXIF extraction methods"""
         logger.debug(f"Using legacy EXIF extraction for {file_path}")
 
@@ -621,10 +621,10 @@ class EnhancedExifExtractor:
 
         return metadata
 
-    def _convert_gps_coordinates(self, coord_tuple: tuple, ref: str) -> float | None:
+    def _convert_gps_coordinates(self, coord_tuple: Tuple, ref: str) -> Optional[float]:
         """Convert GPS coordinates to decimal degrees"""
         try:
-            if isinstance(coord_tuple, list | tuple) and len(coord_tuple) >= 3:
+            if isinstance(coord_tuple, (list, tuple)) and len(coord_tuple) >= 3:
                 degrees = float(coord_tuple[0])
                 minutes = float(coord_tuple[1])
                 seconds = float(coord_tuple[2])
@@ -641,7 +641,7 @@ class EnhancedExifExtractor:
             logger.debug(f"Could not convert GPS coordinates: {e}")
             return None
 
-    def get_capture_datetime(self, metadata: dict[str, Any]) -> datetime | None:
+    def get_capture_datetime(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         """Get the best available capture datetime"""
         date_sources = [
             "datetime_original",
@@ -661,7 +661,7 @@ class EnhancedExifExtractor:
         """Clear the metadata cache"""
         self.cache.clear()
 
-    def get_supported_formats(self) -> list[str]:
+    def get_supported_formats(self) -> List[str]:
         """Get list of supported file formats"""
         if EXIFTOOL_AVAILABLE:
             return [
@@ -747,7 +747,7 @@ class EnhancedExifExtractor:
         else:
             return "Legacy (Basic)"
 
-    def get_exiftool_version(self) -> str | None:
+    def get_exiftool_version(self) -> Optional[str]:
         """Get ExifTool version if available"""
         if EXIFTOOL_AVAILABLE and self.exiftool_session:
             try:
@@ -757,7 +757,7 @@ class EnhancedExifExtractor:
                 return "Unknown"
         return None
 
-    def _extract_video_metadata(self, file_path: Path) -> dict[str, Any]:
+    def _extract_video_metadata(self, file_path: Path) -> Dict[str, Any]:
         """Extract metadata from video files using enhanced video extractor"""
         if self.video_extractor:
             try:

--- a/src/modules/enhanced_video_extractor.py
+++ b/src/modules/enhanced_video_extractor.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 # Suppress specific warnings
 warnings.filterwarnings("ignore", category=UserWarning, module="pymediainfo")
@@ -25,7 +25,7 @@ class EnhancedVideoExtractor:
         self.cache = {}
         self.supported_formats = self._get_supported_formats()
 
-    def _get_supported_formats(self) -> list[str]:
+    def _get_supported_formats(self) -> List[str]:
         """Get list of supported video formats"""
         if MEDIAINFO_AVAILABLE:
             # Professional video formats supported by MediaInfo
@@ -80,7 +80,7 @@ class EnhancedVideoExtractor:
         else:
             return "Basic (Limited)"
 
-    def get_mediainfo_version(self) -> str | None:
+    def get_mediainfo_version(self) -> Optional[str]:
         """Get MediaInfo library version"""
         if MEDIAINFO_AVAILABLE:
             try:
@@ -91,11 +91,11 @@ class EnhancedVideoExtractor:
                 return "Unknown"
         return None
 
-    def get_supported_formats(self) -> list[str]:
+    def get_supported_formats(self) -> List[str]:
         """Get list of supported video formats"""
         return self.supported_formats.copy()
 
-    def extract_metadata(self, file_path: str) -> dict[str, Any]:
+    def extract_metadata(self, file_path: str) -> Dict[str, Any]:
         """Extract comprehensive metadata from video file"""
         file_path_obj = Path(file_path)
 
@@ -122,7 +122,7 @@ class EnhancedVideoExtractor:
         self.cache[cache_key] = metadata.copy()
         return metadata
 
-    def _initialize_basic_metadata(self, file_path: Path) -> dict[str, Any]:
+    def _initialize_basic_metadata(self, file_path: Path) -> Dict[str, Any]:
         """Initialize basic file metadata"""
         return {
             "file_path": str(file_path),
@@ -133,7 +133,7 @@ class EnhancedVideoExtractor:
             "file_created": (datetime.fromtimestamp(file_path.stat().st_ctime) if file_path.exists() else None),
         }
 
-    def _extract_with_mediainfo(self, file_path: str) -> dict[str, Any]:
+    def _extract_with_mediainfo(self, file_path: str) -> Dict[str, Any]:
         """Extract metadata using PyMediaInfo"""
         metadata = {}
 
@@ -154,7 +154,7 @@ class EnhancedVideoExtractor:
 
         return metadata
 
-    def _process_general_track(self, track) -> dict[str, Any]:
+    def _process_general_track(self, track) -> Dict[str, Any]:
         """Process general track information"""
         metadata = {}
 
@@ -205,7 +205,7 @@ class EnhancedVideoExtractor:
 
         return metadata
 
-    def _process_video_track(self, track) -> dict[str, Any]:
+    def _process_video_track(self, track) -> Dict[str, Any]:
         """Process video track information"""
         metadata = {}
 
@@ -253,7 +253,7 @@ class EnhancedVideoExtractor:
 
         return metadata
 
-    def _process_audio_track(self, track) -> dict[str, Any]:
+    def _process_audio_track(self, track) -> Dict[str, Any]:
         """Process audio track information"""
         metadata = {}
 
@@ -279,7 +279,7 @@ class EnhancedVideoExtractor:
 
         return metadata
 
-    def _extract_basic_metadata(self, file_path: Path) -> dict[str, Any]:
+    def _extract_basic_metadata(self, file_path: Path) -> Dict[str, Any]:
         """Extract basic metadata when MediaInfo is not available"""
         metadata = {}
 
@@ -297,7 +297,7 @@ class EnhancedVideoExtractor:
 
         return metadata
 
-    def _parse_mediainfo_datetime(self, date_str: str) -> datetime | None:
+    def _parse_mediainfo_datetime(self, date_str: str) -> Optional[datetime]:
         """Parse datetime from MediaInfo output"""
         if not date_str:
             return None
@@ -348,7 +348,7 @@ class EnhancedVideoExtractor:
         except (ValueError, TypeError):
             return "Unknown"
 
-    def get_capture_datetime(self, metadata: dict[str, Any]) -> datetime | None:
+    def get_capture_datetime(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         """Get the best available capture datetime for video"""
         date_sources = [
             "datetime_original",

--- a/src/modules/exif_extractor.py
+++ b/src/modules/exif_extractor.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Optional, Tuple
 
 import exif
 from PIL import Image
@@ -14,7 +14,7 @@ class ExifExtractor:
     def __init__(self):
         self.cache = {}
 
-    def extract_metadata(self, file_path: str) -> dict[str, Any]:
+    def extract_metadata(self, file_path: str) -> Dict[str, Any]:
         file_path_obj = Path(file_path)
 
         if str(file_path_obj) in self.cache:
@@ -74,7 +74,7 @@ class ExifExtractor:
         }
         return file_path.suffix.lower() in supported_extensions
 
-    def _extract_exif_data(self, file_path: Path) -> dict[str, Any]:
+    def _extract_exif_data(self, file_path: Path) -> Dict[str, Any]:
         exif_dict = {}
 
         try:
@@ -164,7 +164,7 @@ class ExifExtractor:
 
         return exif_dict
 
-    def _extract_gps_data(self, file_path: Path) -> dict[str, Any] | None:
+    def _extract_gps_data(self, file_path: Path) -> Optional[Dict[str, Any]]:
         gps_data = {}
 
         try:
@@ -241,7 +241,7 @@ class ExifExtractor:
 
         return gps_data if gps_data else None
 
-    def _extract_additional_metadata(self, file_path: Path) -> dict[str, Any]:
+    def _extract_additional_metadata(self, file_path: Path) -> Dict[str, Any]:
         metadata = {}
 
         try:
@@ -264,7 +264,7 @@ class ExifExtractor:
 
         return metadata
 
-    def _parse_datetime(self, datetime_string: str) -> datetime | None:
+    def _parse_datetime(self, datetime_string: str) -> Optional[datetime]:
         if not datetime_string:
             return None
 
@@ -287,9 +287,9 @@ class ExifExtractor:
         logger.debug(f"Could not parse datetime: {datetime_string}")
         return None
 
-    def _convert_gps_coordinates(self, coord_tuple: tuple, ref: str) -> float | None:
+    def _convert_gps_coordinates(self, coord_tuple: Tuple, ref: str) -> Optional[float]:
         try:
-            if isinstance(coord_tuple, list | tuple) and len(coord_tuple) >= 3:
+            if isinstance(coord_tuple, (list, tuple)) and len(coord_tuple) >= 3:
                 degrees = float(coord_tuple[0])
                 minutes = float(coord_tuple[1])
                 seconds = float(coord_tuple[2])
@@ -306,7 +306,7 @@ class ExifExtractor:
             logger.debug(f"Could not convert GPS coordinates: {e}")
             return None
 
-    def _convert_gps_coordinates_pil(self, coord_tuple: tuple, ref: str) -> float | None:
+    def _convert_gps_coordinates_pil(self, coord_tuple: Tuple, ref: str) -> Optional[float]:
         try:
             degrees = coord_tuple[0]
             minutes = coord_tuple[1]
@@ -329,7 +329,7 @@ class ExifExtractor:
             logger.debug(f"Could not convert GPS coordinates: {e}")
             return None
 
-    def get_capture_datetime(self, metadata: dict[str, Any]) -> datetime | None:
+    def get_capture_datetime(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         date_sources = [
             "datetime_original",
             "datetime_digitized",

--- a/src/modules/file_renamer.py
+++ b/src/modules/file_renamer.py
@@ -3,7 +3,7 @@ import random
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Optional
 
 from pathvalidate import sanitize_filename
 
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class FileRenamer:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.naming_config = config.get("naming", {})
         self.pattern = self.naming_config.get("pattern", "{year}{month:02d}{day:02d}_{original_name}")
@@ -25,8 +25,8 @@ class FileRenamer:
     def generate_new_name(
         self,
         file_path: str,
-        metadata: dict[str, Any],
-        destination_folder: str | None = None,
+        metadata: Dict[str, Any],
+        destination_folder: Optional[str] = None,
     ) -> str:
         file_path_obj = Path(file_path)
         original_name = file_path_obj.stem
@@ -56,7 +56,7 @@ class FileRenamer:
 
         return final_name
 
-    def _get_datetime_from_metadata(self, metadata: dict[str, Any]) -> datetime | None:
+    def _get_datetime_from_metadata(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         date_sources = self.config.get("organization", {}).get(
             "date_sources",
             [
@@ -113,10 +113,10 @@ class FileRenamer:
     def _create_template_variables(
         self,
         file_path: Path,
-        metadata: dict[str, Any],
+        metadata: Dict[str, Any],
         capture_datetime: datetime,
         original_name: str,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         variables = {
             "original_name": original_name,
             "original_sequence": self._extract_original_sequence(original_name),
@@ -181,7 +181,7 @@ class FileRenamer:
         # Use the new slugger with both make and model for better pattern matching
         return get_camera_slug(camera_make, camera_model, self.camera_names)
 
-    def _format_pattern(self, pattern: str, variables: dict[str, Any]) -> str:
+    def _format_pattern(self, pattern: str, variables: Dict[str, Any]) -> str:
         try:
             formatted = pattern.format(**variables)
 
@@ -240,7 +240,7 @@ class FileRenamer:
     def reset_counters(self):
         self.counters.clear()
 
-    def preview_rename(self, file_path: str, metadata: dict[str, Any]) -> dict[str, str | bool]:
+    def preview_rename(self, file_path: str, metadata: Dict[str, Any]) -> Dict[str, Any]:
         original_path = Path(file_path)
         new_name = self.generate_new_name(file_path, metadata)
 

--- a/src/modules/folder_organizer.py
+++ b/src/modules/folder_organizer.py
@@ -2,13 +2,13 @@ import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class FolderOrganizer:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.org_config = config.get("organization", {})
         self.folder_structure = self.org_config.get("folder_structure", "{year}/{month:02d}/{day:02d}")
@@ -34,9 +34,9 @@ class FolderOrganizer:
     def determine_destination_path(
         self,
         file_path: str,
-        metadata: dict[str, Any],
+        metadata: Dict[str, Any],
         base_destination: str,
-        location_info: dict[str, str] | None = None,
+        location_info: Optional[Dict[str, str]] = None,
     ) -> Path:
         file_path_obj = Path(file_path)
         extension = file_path_obj.suffix.lower()
@@ -59,7 +59,7 @@ class FolderOrganizer:
 
         return destination
 
-    def _get_datetime_from_metadata(self, metadata: dict[str, Any]) -> datetime | None:
+    def _get_datetime_from_metadata(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         date_sources = self.org_config.get(
             "date_sources",
             [
@@ -86,8 +86,8 @@ class FolderOrganizer:
     def _format_folder_structure(
         self,
         capture_datetime: datetime,
-        metadata: dict[str, Any],
-        location_info: dict[str, str] | None = None,
+        metadata: Dict[str, Any],
+        location_info: Optional[Dict[str, str]] = None,
     ) -> str:
         variables = {
             "year": capture_datetime.year,
@@ -137,7 +137,7 @@ class FolderOrganizer:
             logger.error(f"Error formatting folder structure: {e}")
             return f"{variables['year']}/{variables['month']:02d}/{variables['day']:02d}"
 
-    def _prepare_location_variables(self, location_info: dict[str, str]) -> dict[str, str]:
+    def _prepare_location_variables(self, location_info: Dict[str, str]) -> Dict[str, str]:
         """Prepare location variables based on configuration"""
         result = {}
 
@@ -185,7 +185,7 @@ class FolderOrganizer:
 
         return result
 
-    def _determine_file_type_folder(self, extension: str) -> str | None:
+    def _determine_file_type_folder(self, extension: str) -> Optional[str]:
         if not self.separate_raw:
             return None
 
@@ -223,7 +223,7 @@ class FolderOrganizer:
         new_filename: str,
         dry_run: bool = False,
         preserve_original: bool = True,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         source = Path(source_path)
         destination = destination_folder / new_filename
 
@@ -304,7 +304,7 @@ class FolderOrganizer:
         self,
         source_path: str,
         destination_path: str,
-        metadata: dict[str, Any],
+        metadata: Dict[str, Any],
         dry_run: bool = False,
     ) -> bool:
         if dry_run:
@@ -326,7 +326,7 @@ class FolderOrganizer:
             logger.error(f"Error creating sidecar files: {e}")
             return False
 
-    def _generate_xmp_content(self, metadata: dict[str, Any]) -> str:
+    def _generate_xmp_content(self, metadata: Dict[str, Any]) -> str:
         xmp_template = """<?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/">
     <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -633,7 +633,7 @@ class FolderOrganizer:
             .replace("'", "&#39;")
         )
 
-    def get_statistics(self, source_directory: str) -> dict[str, Any]:
+    def get_statistics(self, source_directory: str) -> Dict[str, Any]:
         source_path = Path(source_directory)
 
         if not source_path.exists():

--- a/src/modules/geolocation.py
+++ b/src/modules/geolocation.py
@@ -3,7 +3,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from geopy.exc import GeocoderServiceError, GeocoderTimedOut
 from geopy.geocoders import Nominatim
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class GeolocationService:
-    def __init__(self, config: dict[str, Any], cache_dir: str | None = None):
+    def __init__(self, config: Dict[str, Any], cache_dir: Optional[str] = None):
         self.config = config.get("geolocation", {})
         self.enabled = self.config.get("enabled", True)
         self.reverse_geocode = self.config.get("reverse_geocode", True)
@@ -34,7 +34,7 @@ class GeolocationService:
         self.last_request_time = 0
         self.min_delay = 1.0
 
-    def _load_cache(self) -> dict[str, Any]:
+    def _load_cache(self) -> Dict[str, Any]:
         if not self.cache_lookups or not self.cache_file.exists():
             return {}
 
@@ -55,7 +55,7 @@ class GeolocationService:
         except Exception as e:
             logger.warning(f"Could not save geocache: {e}")
 
-    def get_location_info(self, latitude: float, longitude: float) -> dict[str, str] | None:
+    def get_location_info(self, latitude: float, longitude: float) -> Optional[Dict[str, str]]:
         if not self.enabled or not self.reverse_geocode:
             return None
 
@@ -80,7 +80,7 @@ class GeolocationService:
         key_string = f"{rounded_lat}:{rounded_lon}"
         return hashlib.md5(key_string.encode()).hexdigest()
 
-    def _reverse_geocode(self, latitude: float, longitude: float) -> dict[str, str] | None:
+    def _reverse_geocode(self, latitude: float, longitude: float) -> Optional[Dict[str, str]]:
         current_time = time.time()
         elapsed = current_time - self.last_request_time
 
@@ -138,7 +138,7 @@ class GeolocationService:
 
         return text[:50]
 
-    def _create_display_name(self, location_info: dict[str, str]) -> str:
+    def _create_display_name(self, location_info: Dict[str, str]) -> str:
         parts = []
 
         if location_info.get("city"):
@@ -154,7 +154,7 @@ class GeolocationService:
 
         return ", ".join(parts) if parts else "Unknown Location"
 
-    def format_location_folder(self, location_info: dict[str, str]) -> str:
+    def format_location_folder(self, location_info: Dict[str, str]) -> str:
         if not location_info or not self.add_location_to_folder:
             return ""
 
@@ -172,7 +172,7 @@ class GeolocationService:
             logger.error(f"Error formatting location folder: {e}")
             return ""
 
-    def extract_gps_from_metadata(self, metadata: dict[str, Any]) -> tuple[float, float] | None:
+    def extract_gps_from_metadata(self, metadata: Dict[str, Any]) -> Optional[Tuple[float, float]]:
         if not metadata.get("gps"):
             return None
 
@@ -193,7 +193,7 @@ class GeolocationService:
 
         return None
 
-    def add_location_to_metadata(self, metadata: dict[str, Any]) -> dict[str, Any]:
+    def add_location_to_metadata(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
         if not self.enabled:
             return metadata
 
@@ -209,7 +209,7 @@ class GeolocationService:
 
         return metadata
 
-    def create_location_map(self, photos_with_location: list) -> dict[str, list]:
+    def create_location_map(self, photos_with_location: List) -> Dict[str, List]:
         location_map = {}
 
         for photo_info in photos_with_location:
@@ -231,7 +231,7 @@ class GeolocationService:
 
         return location_map
 
-    def export_kml(self, photos_with_location: list, output_path: str):
+    def export_kml(self, photos_with_location: List, output_path: str):
         kml_template = """<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
   <Document>

--- a/src/modules/image_processor.py
+++ b/src/modules/image_processor.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from PIL import Image, ImageEnhance
 from PIL.Image import Resampling, Transpose
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 
 
 class ImageProcessor:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.processing_config = config.get("image_processing", {})
         self.auto_rotate = self.processing_config.get("auto_rotate", True)
@@ -20,10 +20,10 @@ class ImageProcessor:
     def process_image(
         self,
         image_path: str,
-        metadata: dict[str, Any],
-        output_path: str | None = None,
+        metadata: Dict[str, Any],
+        output_path: Optional[str] = None,
         dry_run: bool = False,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Process image with auto-rotation and optional enhancements"""
         result = {
             "original_path": image_path,
@@ -87,7 +87,7 @@ class ImageProcessor:
 
         return result
 
-    def _auto_rotate_image(self, img: Image.Image, metadata: dict[str, Any]) -> Image.Image:
+    def _auto_rotate_image(self, img: Image.Image, metadata: Dict[str, Any]) -> Image.Image:
         """Auto-rotate image based on EXIF orientation"""
         orientation = metadata.get("orientation")
 
@@ -144,7 +144,7 @@ class ImageProcessor:
             logger.debug(f"Error in auto-enhancement: {e}")
             return img
 
-    def _generate_thumbnails(self, img: Image.Image, original_path: str, output_base_path: str) -> list[str]:
+    def _generate_thumbnails(self, img: Image.Image, original_path: str, output_base_path: str) -> List[str]:
         """Generate thumbnails in multiple sizes"""
         thumbnails = []
         base_path = Path(output_base_path)
@@ -173,7 +173,7 @@ class ImageProcessor:
 
         return thumbnails
 
-    def _needs_processing(self, metadata: dict[str, Any]) -> bool:
+    def _needs_processing(self, metadata: Dict[str, Any]) -> bool:
         """Check if image needs processing based on metadata"""
         needs_rotation = False
 
@@ -183,7 +183,7 @@ class ImageProcessor:
 
         return needs_rotation or self.auto_enhance or self.generate_thumbnails
 
-    def get_social_media_specs(self, platform: str) -> dict[str, Any]:
+    def get_social_media_specs(self, platform: str) -> Dict[str, Any]:
         """Get platform-specific image specifications"""
         specs = {
             "instagram": {
@@ -216,9 +216,9 @@ class ImageProcessor:
         image_path: str,
         platform: str,
         format_type: str = "post",
-        output_dir: str = None,
+        output_dir: Optional[str] = None,
         dry_run: bool = False,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Optimize image for specific social media platform"""
         result = {
             "original_path": image_path,
@@ -302,12 +302,12 @@ class ImageProcessor:
 
     def batch_optimize_for_social_media(
         self,
-        image_paths: list[str],
+        image_paths: List[str],
         platform: str,
         format_type: str = "post",
-        output_dir: str = None,
+        output_dir: Optional[str] = None,
         dry_run: bool = False,
-    ) -> list[dict[str, Any]]:
+    ) -> List[Dict[str, Any]]:
         """Batch optimize multiple images for social media"""
         results = []
 

--- a/src/modules/session_detector.py
+++ b/src/modules/session_detector.py
@@ -1,13 +1,13 @@
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 class SessionDetector:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.session_config = config.get("session_detection", {})
         self.time_gap_minutes = self.session_config.get("time_gap_minutes", 30)
@@ -15,7 +15,7 @@ class SessionDetector:
         self.same_location_threshold_km = self.session_config.get("same_location_threshold_km", 1.0)
         self.enable_location_grouping = self.session_config.get("enable_location_grouping", True)
 
-    def detect_sessions(self, photos_metadata: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def detect_sessions(self, photos_metadata: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Detect shooting sessions from a list of photo metadata"""
         if not photos_metadata:
             return []
@@ -59,7 +59,7 @@ class SessionDetector:
         logger.info(f"Detected {len(sessions)} shooting sessions from {len(photos_metadata)} photos")
         return sessions
 
-    def _get_capture_time(self, metadata: dict[str, Any]) -> datetime | None:
+    def _get_capture_time(self, metadata: Dict[str, Any]) -> Optional[datetime]:
         """Extract capture time from metadata"""
         time_fields = [
             "datetime_original",
@@ -84,8 +84,8 @@ class SessionDetector:
         self,
         last_time: datetime,
         current_time: datetime,
-        current_session: list[dict[str, Any]],
-        current_photo: dict[str, Any],
+        current_session: List[Dict[str, Any]],
+        current_photo: Dict[str, Any],
     ) -> bool:
         """Determine if current photo belongs to the same session"""
         # Check time gap
@@ -100,7 +100,7 @@ class SessionDetector:
 
         return True
 
-    def _is_same_location(self, current_session: list[dict[str, Any]], current_photo: dict[str, Any]) -> bool:
+    def _is_same_location(self, current_session: List[Dict[str, Any]], current_photo: Dict[str, Any]) -> bool:
         """Check if current photo is at the same location as session"""
         current_gps = current_photo.get("gps")
         if not current_gps:
@@ -147,7 +147,7 @@ class SessionDetector:
 
         return earth_radius_km * c
 
-    def _create_session_info(self, session_photos: list[dict[str, Any]]) -> dict[str, Any]:
+    def _create_session_info(self, session_photos: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Create session information from list of photos"""
         start_time = self._get_capture_time(session_photos[0])
         end_time = self._get_capture_time(session_photos[-1])
@@ -202,7 +202,7 @@ class SessionDetector:
             "file_paths": [photo["file_path"] for photo in session_photos],
         }
 
-    def _generate_session_name(self, session: dict[str, Any], session_number: int) -> str:
+    def _generate_session_name(self, session: Dict[str, Any], session_number: int) -> str:
         """Generate a descriptive name for the session"""
         start_time = session["start_time"]
         location_name = session.get("location_name")
@@ -231,11 +231,11 @@ class SessionDetector:
 
     def organize_by_sessions(
         self,
-        sessions: list[dict[str, Any]],
+        sessions: List[Dict[str, Any]],
         base_output_dir: str,
         session_folder_pattern: str = "{session_name}",
         dry_run: bool = False,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Organize photos into session-based folder structure"""
         result = {
             "sessions_processed": 0,
@@ -268,7 +268,7 @@ class SessionDetector:
 
         return result
 
-    def get_session_statistics(self, sessions: list[dict[str, Any]]) -> dict[str, Any]:
+    def get_session_statistics(self, sessions: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Generate statistics about detected sessions"""
         if not sessions:
             return {"total_sessions": 0}

--- a/src/modules/statistics_generator.py
+++ b/src/modules/statistics_generator.py
@@ -2,7 +2,7 @@ import logging
 from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -13,14 +13,14 @@ logger = logging.getLogger(__name__)
 
 
 class StatisticsGenerator:
-    def __init__(self, config: dict[str, Any]):
+    def __init__(self, config: Dict[str, Any]):
         self.config = config
         self.stats_config = config.get("statistics", {})
         self.console = Console()
         self.enable_charts = self.stats_config.get("enable_charts", True)
         self.chart_output_dir = self.stats_config.get("chart_output_dir", "charts")
 
-    def generate_library_statistics(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def generate_library_statistics(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Generate comprehensive statistics for the photo library"""
         if not photos_metadata:
             return {"error": "No photos provided for analysis"}
@@ -39,7 +39,7 @@ class StatisticsGenerator:
 
         return stats
 
-    def _calculate_date_range(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _calculate_date_range(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Calculate date range of photos"""
         dates = []
         for photo in photos_metadata:
@@ -61,7 +61,7 @@ class StatisticsGenerator:
             "total_photos_with_dates": len(dates),
         }
 
-    def _analyze_cameras(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_cameras(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze camera usage statistics"""
         camera_counts = Counter()
         camera_models = Counter()
@@ -86,7 +86,7 @@ class StatisticsGenerator:
             "model_distribution": dict(camera_models.most_common()),
         }
 
-    def _analyze_lenses(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_lenses(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze lens usage statistics"""
         lens_counts = Counter()
         focal_lengths = []
@@ -97,7 +97,7 @@ class StatisticsGenerator:
                 lens_counts[lens] += 1
 
             focal_length = photo.get("focal_length")
-            if focal_length and isinstance(focal_length, int | float):
+            if focal_length and isinstance(focal_length, (int, float)):
                 focal_lengths.append(focal_length)
 
         focal_length_stats = {}
@@ -117,7 +117,7 @@ class StatisticsGenerator:
             "focal_length_stats": focal_length_stats,
         }
 
-    def _analyze_technical_settings(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_technical_settings(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze camera technical settings"""
         iso_values = []
         aperture_values = []
@@ -125,15 +125,15 @@ class StatisticsGenerator:
 
         for photo in photos_metadata:
             iso = photo.get("iso")
-            if iso and isinstance(iso, int | float):
+            if iso and isinstance(iso, (int, float)):
                 iso_values.append(iso)
 
             f_number = photo.get("f_number")
-            if f_number and isinstance(f_number, int | float):
+            if f_number and isinstance(f_number, (int, float)):
                 aperture_values.append(f_number)
 
             exposure = photo.get("exposure_time")
-            if exposure and isinstance(exposure, int | float):
+            if exposure and isinstance(exposure, (int, float)):
                 shutter_speeds.append(exposure)
 
         stats = {}
@@ -166,7 +166,7 @@ class StatisticsGenerator:
 
         return stats
 
-    def _analyze_file_info(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_file_info(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze file information"""
         file_sizes = []
         extensions = Counter()
@@ -174,7 +174,7 @@ class StatisticsGenerator:
 
         for photo in photos_metadata:
             size = photo.get("file_size")
-            if size and isinstance(size, int | float):
+            if size and isinstance(size, (int, float)):
                 file_sizes.append(size)
 
             ext = photo.get("file_extension", "").lower()
@@ -209,7 +209,7 @@ class StatisticsGenerator:
 
         return stats
 
-    def _analyze_locations(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_locations(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze location information"""
         locations = Counter()
         countries = Counter()
@@ -245,7 +245,7 @@ class StatisticsGenerator:
             "cities_visited": dict(cities.most_common(10)),
         }
 
-    def _analyze_shooting_patterns(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_shooting_patterns(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze shooting patterns over time"""
         photos_by_month = defaultdict(int)
         photos_by_hour = defaultdict(int)
@@ -268,7 +268,7 @@ class StatisticsGenerator:
             "most_active_weekday": (max(photos_by_weekday.items(), key=lambda x: x[1]) if photos_by_weekday else None),
         }
 
-    def _analyze_quality_metrics(self, photos_metadata: list[dict[str, Any]]) -> dict[str, Any]:
+    def _analyze_quality_metrics(self, photos_metadata: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Analyze image quality metrics"""
         # This is a placeholder for quality analysis
         # In a real implementation, you might analyze:
@@ -282,7 +282,7 @@ class StatisticsGenerator:
             "available_metrics": [],
         }
 
-    def _get_photo_date(self, photo: dict[str, Any]) -> datetime | None:
+    def _get_photo_date(self, photo: Dict[str, Any]) -> Optional[datetime]:
         """Extract photo date from metadata"""
         date_fields = [
             "datetime_original",
@@ -303,7 +303,7 @@ class StatisticsGenerator:
 
         return None
 
-    def display_statistics(self, stats: dict[str, Any]) -> None:
+    def display_statistics(self, stats: Dict[str, Any]) -> None:
         """Display statistics in a formatted console output"""
         self.console.print("\n[bold cyan]📊 LensLogic Library Statistics[/bold cyan]\n")
 
@@ -407,7 +407,7 @@ class StatisticsGenerator:
 
                 self.console.print(location_table)
 
-    def generate_charts(self, stats: dict[str, Any], output_dir: str = None) -> list[str]:
+    def generate_charts(self, stats: Dict[str, Any], output_dir: Optional[str] = None) -> List[str]:
         """Generate statistical charts"""
         if not self.enable_charts:
             return []
@@ -444,7 +444,7 @@ class StatisticsGenerator:
 
         return charts_created
 
-    def _create_shooting_patterns_chart(self, patterns: dict[str, Any], output_path: Path) -> str | None:
+    def _create_shooting_patterns_chart(self, patterns: Dict[str, Any], output_path: Path) -> Optional[str]:
         """Create shooting patterns chart"""
         try:
             fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
@@ -482,7 +482,7 @@ class StatisticsGenerator:
             logger.error(f"Error creating shooting patterns chart: {e}")
             return None
 
-    def _create_camera_usage_chart(self, camera_stats: dict[str, Any], output_path: Path) -> str | None:
+    def _create_camera_usage_chart(self, camera_stats: Dict[str, Any], output_path: Path) -> Optional[str]:
         """Create camera usage pie chart"""
         try:
             if not camera_stats.get("camera_distribution"):
@@ -506,7 +506,7 @@ class StatisticsGenerator:
             logger.error(f"Error creating camera usage chart: {e}")
             return None
 
-    def _create_technical_settings_chart(self, tech_stats: dict[str, Any], output_path: Path) -> str | None:
+    def _create_technical_settings_chart(self, tech_stats: Dict[str, Any], output_path: Path) -> Optional[str]:
         """Create technical settings distribution chart"""
         try:
             fig, axes = plt.subplots(1, 3, figsize=(18, 6))

--- a/src/modules/xmp_analyzer.py
+++ b/src/modules/xmp_analyzer.py
@@ -9,7 +9,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Optional, Tuple
 
 from rich.console import Console
 from rich.progress import Progress
@@ -36,7 +36,7 @@ class PhotoMetadata:
     software: str = ""
     artist: str = ""
     copyright: str = ""
-    keywords: list[str] | None = None
+    keywords: Optional[List[str]] = None
     rating: str = ""
     color_space: str = ""
     bit_depth: str = ""
@@ -56,12 +56,12 @@ class PhotoMetadata:
 class XMPAnalyzer:
     """Analyzes photo libraries using XMP sidecar files"""
 
-    def __init__(self, console: Console | None = None):
+    def __init__(self, console: Optional[Console] = None):
         self.console = console or Console()
-        self.photos: list[PhotoMetadata] = []
+        self.photos: List[PhotoMetadata] = []
         self.total_files_processed = 0
         self.xmp_files_found = 0
-        self.errors: list[tuple[str, str]] = []
+        self.errors: List[Tuple[str, str]] = []
 
         # XMP namespace mappings
         self.namespaces = {
@@ -78,7 +78,7 @@ class XMPAnalyzer:
             "xmpMM": "http://ns.adobe.com/xap/1.0/mm/",
         }
 
-    def analyze_library(self, root_directory: str, output_dir: str | None = None) -> dict[str, Any]:
+    def analyze_library(self, root_directory: str, output_dir: Optional[str] = None) -> Dict[str, Any]:
         """
         Analyze a photo library by scanning XMP files
 
@@ -133,14 +133,14 @@ class XMPAnalyzer:
 
         return analysis
 
-    def _find_xmp_files(self, root_path: Path) -> list[Path]:
+    def _find_xmp_files(self, root_path: Path) -> List[Path]:
         """Find all XMP files in the directory tree"""
         xmp_files = []
         for path in root_path.rglob("*.xmp"):
             xmp_files.append(path)
         return sorted(xmp_files)
 
-    def _parse_xmp_file(self, xmp_path: Path) -> PhotoMetadata | None:
+    def _parse_xmp_file(self, xmp_path: Path) -> Optional[PhotoMetadata]:
         """Parse an XMP file and extract metadata"""
         try:
             # Get associated media file info
@@ -183,7 +183,7 @@ class XMPAnalyzer:
         except Exception as e:
             raise Exception(f"Failed to parse XMP file: {e}") from e
 
-    def _find_associated_media_file(self, xmp_path: Path) -> Path | None:
+    def _find_associated_media_file(self, xmp_path: Path) -> Optional[Path]:
         """Find the media file associated with an XMP sidecar"""
         base_name = xmp_path.stem
         parent_dir = xmp_path.parent
@@ -392,7 +392,7 @@ class XMPAnalyzer:
                     keywords.append(li.text.strip())
             metadata.keywords = keywords
 
-    def _generate_analysis(self) -> dict[str, Any]:
+    def _generate_analysis(self) -> Dict[str, Any]:
         """Generate comprehensive analysis from collected metadata"""
         if not self.photos:
             return self._create_empty_report()
@@ -413,7 +413,7 @@ class XMPAnalyzer:
 
         return analysis
 
-    def _analyze_summary(self) -> dict[str, Any]:
+    def _analyze_summary(self) -> Dict[str, Any]:
         """Generate summary statistics"""
         total_photos = len(self.photos)
         photos_with_gps = len([p for p in self.photos if p.gps_latitude and p.gps_longitude])
@@ -433,7 +433,7 @@ class XMPAnalyzer:
             "location_coverage_percentage": ((photos_with_location / total_photos * 100) if total_photos > 0 else 0),
         }
 
-    def _analyze_cameras(self) -> dict[str, Any]:
+    def _analyze_cameras(self) -> Dict[str, Any]:
         """Analyze camera usage patterns"""
         camera_counts = Counter()
         make_counts = Counter()
@@ -459,7 +459,7 @@ class XMPAnalyzer:
             "most_used_make": make_counts.most_common(1)[0] if make_counts else None,
         }
 
-    def _analyze_lenses(self) -> dict[str, Any]:
+    def _analyze_lenses(self) -> Dict[str, Any]:
         """Analyze lens usage patterns"""
         lens_counts = Counter()
         focal_length_counts = Counter()
@@ -494,7 +494,7 @@ class XMPAnalyzer:
             "most_used_lens": lens_counts.most_common(1)[0] if lens_counts else None,
         }
 
-    def _analyze_locations(self) -> dict[str, Any]:
+    def _analyze_locations(self) -> Dict[str, Any]:
         """Analyze location patterns"""
         city_counts = Counter()
         country_counts = Counter()
@@ -523,7 +523,7 @@ class XMPAnalyzer:
             "most_photographed_country": (country_counts.most_common(1)[0] if country_counts else None),
         }
 
-    def _analyze_exposure_settings(self) -> dict[str, Any]:
+    def _analyze_exposure_settings(self) -> Dict[str, Any]:
         """Analyze exposure settings patterns"""
         f_number_counts = Counter()
         iso_counts = Counter()
@@ -545,7 +545,7 @@ class XMPAnalyzer:
             "most_used_iso": iso_counts.most_common(1)[0] if iso_counts else None,
         }
 
-    def _analyze_temporal_patterns(self) -> dict[str, Any]:
+    def _analyze_temporal_patterns(self) -> Dict[str, Any]:
         """Analyze temporal shooting patterns"""
         years = Counter()
         months = Counter()
@@ -582,7 +582,7 @@ class XMPAnalyzer:
             "most_active_day": days_of_week.most_common(1)[0] if days_of_week else None,
         }
 
-    def _analyze_technical_specs(self) -> dict[str, Any]:
+    def _analyze_technical_specs(self) -> Dict[str, Any]:
         """Analyze technical specifications"""
         resolutions = Counter()
         bit_depths = Counter()
@@ -615,7 +615,7 @@ class XMPAnalyzer:
             "largest_file_size_mb": (max(file_sizes) / (1024 * 1024) if file_sizes else 0),
         }
 
-    def _analyze_video_content(self) -> dict[str, Any]:
+    def _analyze_video_content(self) -> Dict[str, Any]:
         """Analyze video-specific content"""
         video_codecs = Counter()
         framerates = Counter()
@@ -649,7 +649,7 @@ class XMPAnalyzer:
             "average_video_length_seconds": (sum(durations) / len(durations) if durations else 0),
         }
 
-    def _analyze_creators(self) -> dict[str, Any]:
+    def _analyze_creators(self) -> Dict[str, Any]:
         """Analyze creator and software information"""
         software_counts = Counter()
         creator_counts = Counter()
@@ -666,7 +666,7 @@ class XMPAnalyzer:
             "most_used_software": (software_counts.most_common(1)[0] if software_counts else None),
         }
 
-    def _analyze_keywords(self) -> dict[str, Any]:
+    def _analyze_keywords(self) -> Dict[str, Any]:
         """Analyze keywords and tags"""
         all_keywords = []
         for photo in self.photos:
@@ -682,7 +682,7 @@ class XMPAnalyzer:
             "most_used_keyword": (keyword_counts.most_common(1)[0] if keyword_counts else None),
         }
 
-    def _analyze_files(self) -> dict[str, Any]:
+    def _analyze_files(self) -> Dict[str, Any]:
         """Analyze file organization patterns"""
         folder_counts = Counter()
         file_extensions = Counter()
@@ -701,7 +701,7 @@ class XMPAnalyzer:
             "most_populated_folder": (folder_counts.most_common(1)[0] if folder_counts else None),
         }
 
-    def _create_empty_report(self) -> dict[str, Any]:
+    def _create_empty_report(self) -> Dict[str, Any]:
         """Create an empty report structure"""
         return {
             "summary": {"total_files": 0, "xmp_files_found": 0},
@@ -717,7 +717,7 @@ class XMPAnalyzer:
             "file_analysis": {},
         }
 
-    def _save_detailed_reports(self, analysis: dict[str, Any], output_dir: str):
+    def _save_detailed_reports(self, analysis: Dict[str, Any], output_dir: str):
         """Save detailed analysis reports"""
         output_path = Path(output_dir)
         output_path.mkdir(parents=True, exist_ok=True)
@@ -747,7 +747,7 @@ class XMPAnalyzer:
                     row["keywords"] = "; ".join(row["keywords"]) if row["keywords"] else ""
                     writer.writerow(row)
 
-    def display_analysis(self, analysis: dict[str, Any]):
+    def display_analysis(self, analysis: Dict[str, Any]):
         """Display analysis results in a formatted way"""
         self._display_summary(analysis["summary"])
         self._display_cameras(analysis["cameras"])
@@ -760,7 +760,7 @@ class XMPAnalyzer:
         if analysis["video_analysis"].get("video_codec_distribution"):
             self._display_video_analysis(analysis["video_analysis"])
 
-    def _display_summary(self, summary: dict[str, Any]):
+    def _display_summary(self, summary: Dict[str, Any]):
         """Display summary statistics"""
         table = Table(title="📊 Library Summary", show_header=True, header_style="bold cyan")
         table.add_column("Metric", style="bold")
@@ -780,7 +780,7 @@ class XMPAnalyzer:
         self.console.print(table)
         self.console.print()
 
-    def _display_cameras(self, cameras: dict[str, Any]):
+    def _display_cameras(self, cameras: Dict[str, Any]):
         """Display camera statistics"""
         if not cameras.get("camera_distribution"):
             return
@@ -799,7 +799,7 @@ class XMPAnalyzer:
         self.console.print(table)
         self.console.print()
 
-    def _display_lenses(self, lenses: dict[str, Any]):
+    def _display_lenses(self, lenses: Dict[str, Any]):
         """Display lens statistics"""
         if not lenses.get("lens_distribution"):
             return
@@ -830,7 +830,7 @@ class XMPAnalyzer:
             self.console.print(focal_table)
             self.console.print()
 
-    def _display_locations(self, locations: dict[str, Any]):
+    def _display_locations(self, locations: Dict[str, Any]):
         """Display location statistics"""
         if locations.get("country_distribution"):
             table = Table(
@@ -847,7 +847,7 @@ class XMPAnalyzer:
             self.console.print(table)
             self.console.print()
 
-    def _display_exposure_settings(self, exposure: dict[str, Any]):
+    def _display_exposure_settings(self, exposure: Dict[str, Any]):
         """Display exposure settings statistics"""
         if exposure.get("most_used_aperture"):
             table = Table(
@@ -870,7 +870,7 @@ class XMPAnalyzer:
             self.console.print(table)
             self.console.print()
 
-    def _display_temporal_analysis(self, temporal: dict[str, Any]):
+    def _display_temporal_analysis(self, temporal: Dict[str, Any]):
         """Display temporal analysis"""
         if temporal.get("most_active_year"):
             table = Table(
@@ -897,7 +897,7 @@ class XMPAnalyzer:
             self.console.print(table)
             self.console.print()
 
-    def _display_technical_specs(self, technical: dict[str, Any]):
+    def _display_technical_specs(self, technical: Dict[str, Any]):
         """Display technical specifications"""
         table = Table(
             title="⚙️  Technical Specifications",
@@ -914,7 +914,7 @@ class XMPAnalyzer:
         self.console.print(table)
         self.console.print()
 
-    def _display_video_analysis(self, video: dict[str, Any]):
+    def _display_video_analysis(self, video: Dict[str, Any]):
         """Display video analysis"""
         table = Table(title="🎬 Video Content", show_header=True, header_style="bold cyan")
         table.add_column("Metric", style="bold")

--- a/src/utils/camera_slugger.py
+++ b/src/utils/camera_slugger.py
@@ -3,12 +3,13 @@ Camera name slugification utilities for professional photo organization
 """
 
 import re
+from typing import Dict, Optional
 
 
 class CameraSlugger:
     """Converts camera names to clean, consistent slugs for file organization"""
 
-    def __init__(self, custom_mappings: dict[str, str] | None = None):
+    def __init__(self, custom_mappings: Optional[Dict[str, str]] = None):
         """
         Initialize with optional custom mappings
 
@@ -141,7 +142,7 @@ class CameraSlugger:
 
         return slug or "unknown"
 
-    def get_examples(self) -> dict[str, str]:
+    def get_examples(self) -> Dict[str, str]:
         """Get examples of camera name to slug conversions"""
         examples = {
             # iPhone examples
@@ -187,7 +188,7 @@ class CameraSlugger:
 def get_camera_slug(
     camera_make: str = "",
     camera_model: str = "",
-    custom_mappings: dict[str, str] | None = None,
+    custom_mappings: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Convenience function to get a camera slug

--- a/src/utils/config_manager.py
+++ b/src/utils/config_manager.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, Optional
 
 import yaml
 
@@ -8,9 +8,9 @@ logger = logging.getLogger(__name__)
 
 
 class ConfigManager:
-    def __init__(self, config_path: str | None = None):
+    def __init__(self, config_path: Optional[str] = None):
         self.config_path = config_path
-        self.config: dict[str, Any] = {}
+        self.config: Dict[str, Any] = {}
         self.default_config_path = Path(__file__).parent.parent.parent / "config" / "default_config.yaml"
         self.user_config_path = Path.home() / ".lenslogic" / "config.yaml"
         self.load_config()
@@ -27,7 +27,7 @@ class ConfigManager:
             if custom_config:
                 self.config = self._merge_configs(self.config, custom_config)
 
-    def _load_default_config(self) -> dict[str, Any]:
+    def _load_default_config(self) -> Dict[str, Any]:
         try:
             with open(self.default_config_path) as f:
                 return yaml.safe_load(f) or {}
@@ -38,7 +38,7 @@ class ConfigManager:
             logger.error(f"Error parsing default config: {e}")
             return self._get_hardcoded_defaults()
 
-    def _load_user_config(self) -> dict[str, Any] | None:
+    def _load_user_config(self) -> Optional[Dict[str, Any]]:
         if not self.user_config_path.exists():
             return None
 
@@ -49,7 +49,7 @@ class ConfigManager:
             logger.error(f"Error parsing user config: {e}")
             return None
 
-    def _load_custom_config(self) -> dict[str, Any] | None:
+    def _load_custom_config(self) -> Optional[Dict[str, Any]]:
         if not self.config_path or not Path(self.config_path).exists():
             return None
 
@@ -60,7 +60,7 @@ class ConfigManager:
             logger.error(f"Error parsing custom config: {e}")
             return None
 
-    def _merge_configs(self, base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    def _merge_configs(self, base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
         result = base.copy()
 
         for key, value in override.items():
@@ -71,7 +71,7 @@ class ConfigManager:
 
         return result
 
-    def _get_hardcoded_defaults(self) -> dict[str, Any]:
+    def _get_hardcoded_defaults(self) -> Dict[str, Any]:
         return {
             "general": {
                 "source_directory": ".",
@@ -194,7 +194,7 @@ class ConfigManager:
 
         logger.info(f"Configuration exported to {path}")
 
-    def update_from_args(self, args: dict[str, Any]) -> None:
+    def update_from_args(self, args: Dict[str, Any]) -> None:
         if args.get("source"):
             self.set("general.source_directory", args["source"])
         if args.get("destination"):

--- a/src/utils/progress_tracker.py
+++ b/src/utils/progress_tracker.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict
 
 from rich.console import Console
 from rich.panel import Panel
@@ -162,7 +162,7 @@ class ProgressTracker:
     def print_dry_run(self, message: str):
         self.console.print(f"[cyan][DRY RUN][/cyan] {message}")
 
-    def display_file_preview(self, original: str, new_name: str, destination: str, metadata: dict[str, Any]):
+    def display_file_preview(self, original: str, new_name: str, destination: str, metadata: Dict[str, Any]):
         panel_content = f"""
 [bold]Original:[/bold] {Path(original).name}
 [bold]New Name:[/bold] {new_name}
@@ -187,7 +187,7 @@ class ProgressTracker:
 
         self.console.print(panel)
 
-    def create_statistics_table(self, stats: dict[str, Any]) -> Table:
+    def create_statistics_table(self, stats: Dict[str, Any]) -> Table:
         table = Table(title="Library Statistics", show_header=True, header_style="bold magenta")
 
         table.add_column("File Type", style="cyan")


### PR DESCRIPTION
- Replace `str | None` with `Optional[str]`
- Replace `dict[str, Any]` with `Dict[str, Any]`
- Replace `dict[str, Any] | None` with `Optional[Dict[str, Any]]`
- Add `Dict` and `Optional` imports from typing module

This resolves the TypeError: unsupported operand type(s) for |: 'type' and 'NoneType' error that occurred when running with Python 3.8.